### PR TITLE
OTP support for da1469x

### DIFF
--- a/ezFlashCLI/cli.py
+++ b/ezFlashCLI/cli.py
@@ -303,9 +303,18 @@ class ezFlashCLI:
             self.probeFlash()
             self.importAndAssignDevice(self.deviceType)
             self.da.connect(self.args.jlink)
-            self.da.flash_configure_controller(self.flashid)
-            offset = self.da.otp_read(self.args.key)
+            count, offset = self.da.otp_read(self.args.key)
             if (offset < 0):
+                sys.exit(1)
+
+        elif self.args.operation == "write_otp":
+
+            self.probeDevice()
+            self.probeFlash()
+            self.importAndAssignDevice(self.deviceType)
+            self.da.connect(self.args.jlink)
+            result = self.da.otp_write(self.args.key, self.args.values, self.args.force)
+            if (result < 0):
                 sys.exit(1)
 
         else:
@@ -427,11 +436,25 @@ class ezFlashCLI:
             "erase_flash", help="Perform Chip Erase on SPI/QSPI flash"
         )
 
-        otp_parser = self.subparsers.add_parser(
-            "read_otp", help="Read specified OTP value"
+        otp_read_parser = self.subparsers.add_parser(
+            "read_otp", help="Read specified OTP config script value"
         )
-        otp_parser.add_argument(
-            "key", nargs="?", type=lambda x: int(x, 0), default=0xffffffff, help="Key to read"
+        otp_read_parser.add_argument(
+            "key", nargs="?", type=lambda x: int(x, 0), default=0xffffffff, help="Key to read (example: 0x100c0040)"
+        )
+
+        otp_write_parser = self.subparsers.add_parser(
+            "write_otp", help="Write specified OTP config script value"
+        )
+        otp_write_parser.add_argument(
+            "key", type=lambda x: int(x, 0), help="Key to write (example: 0x50020A18)"
+        )
+        otp_write_parser.add_argument(
+            "values", nargs="+", type=lambda x: int(x, 0), help="Value(s) to write (example: 0x200)"
+        )
+
+        otp_write_parser.add_argument(
+            "--force", help="Force adding key even if it already exists", action="store_true"
         )
 
         flash_parser = self.subparsers.add_parser(

--- a/ezFlashCLI/cli.py
+++ b/ezFlashCLI/cli.py
@@ -297,6 +297,17 @@ class ezFlashCLI:
             else:
                 logging.error("Product header mismatch")
 
+        elif self.args.operation == "read_otp":
+
+            self.probeDevice()
+            self.probeFlash()
+            self.importAndAssignDevice(self.deviceType)
+            self.da.connect(self.args.jlink)
+            self.da.flash_configure_controller(self.flashid)
+            offset = self.da.otp_read(self.args.key)
+            if (offset < 0):
+                sys.exit(1)
+
         else:
             self.parser.print_help(sys.stderr)
         sys.exit(0)
@@ -414,6 +425,13 @@ class ezFlashCLI:
         self.subparsers.add_parser("go", help="Reset and start the CPU")
         self.subparsers.add_parser(
             "erase_flash", help="Perform Chip Erase on SPI/QSPI flash"
+        )
+
+        otp_parser = self.subparsers.add_parser(
+            "read_otp", help="Read specified OTP value"
+        )
+        otp_parser.add_argument(
+            "key", nargs="?", type=lambda x: int(x, 0), default=0xffffffff, help="Key to read"
         )
 
         flash_parser = self.subparsers.add_parser(

--- a/ezFlashCLI/ezFlash/smartbond/smartbondDevices.py
+++ b/ezFlashCLI/ezFlash/smartbond/smartbondDevices.py
@@ -163,6 +163,12 @@ class da14xxx:
         """
         pass
 
+    def otp_read(self, key):
+        logging.error("OTP not implemented for this device")
+        return 0, -9
+    def otp_write(self, key, values, force):
+        logging.error("OTP not implemented for this device")
+        return -9
 
 class da1453x_da1458x(da14xxx):
     """Derived class for the DA145xx and DA1458xx devices."""
@@ -605,29 +611,6 @@ class da1468x_da1469x_da1470x(da14xxx):
     QSPIC_WRITEDATA_REG = 0x18  # write data registers in manual mode
     QSPIC_READDATA_REG = 0x1C  # read data registers in manual mode
 
-    OTPC_MODE_REG = 0x00  # Mode register
-    OTPC_STAT_REG = 0x04  # Status register 
-    OTPC_PADDR_REG = 0x08  # The address of the word that will be programmed
-    OTPC_PWORD_REG = 0x0C  # The 32-bit word that will be programmed
-    OTPC_TIM1_REG = 0x10  # Various timing parameters of the OTP cell
-    OTPC_TIM2_REG = 0x14  # Various timing parameters of the OTP cell
-
-    OTPC_MODE_PDOWN = 0 # OTP cell and LDO are inactive
-    OTPC_MODE_DSTBY = 1 # OTP cell is powered on LDO is inactive
-    OTPC_MODE_STBY = 2 # OTP cell and LDO are powered on, chip select is deactivated
-    OTPC_MODE_READ = 3 # OTP cell can be read
-    OTPC_MODE_PROG = 4 # OTP cell can be programmed
-    OTPC_MODE_PVFY = 5 # OTP cell can be read in PVFY margin read mode
-    OTPC_MODE_RINI = 6 # OTP cell can be read in RINI margin read mode
-    OTPC_TIM1_REG_RESET = 0x0999101f
-    OTPC_TIM2_REG_RESET = 0xa4040409
-
-    OTP_BASE = 0x10080000
-    OTP_CFG_SCRIPT_OFFSET = 0x0C00
-    OTP_CFG_SCRIPT_ADDR = OTP_BASE + OTP_CFG_SCRIPT_OFFSET
-    OTP_CFG_SCRIPT_ENTRY_SIZE = 4
-    OTP_CFG_SCRIPT_ENTRY_CNT_MAX = 256
-
     def __init__(self, device=None):
         """Initialize the QSPI controller and parent class."""
         da14xxx.__init__(self, device)
@@ -640,174 +623,7 @@ class da1468x_da1469x_da1470x(da14xxx):
         self.QSPIC_WRITEDATA_REG += self.QPSPIC_BASE
         self.QSPIC_READDATA_REG += self.QPSPIC_BASE
 
-        self.OTPC_MODE_REG += self.OTPC_BASE
-        self.OTPC_STAT_REG += self.OTPC_BASE
-        self.OTPC_PADDR_REG += self.OTPC_BASE
-        self.OTPC_PWORD_REG += self.OTPC_BASE
-        self.OTPC_TIM1_REG += self.OTPC_BASE
-        self.OTPC_TIM2_REG += self.OTPC_BASE
-
         self.myaddress = 0x0
-
-    def otp_init(self):
-        """Init the OTP controller."""
-
-        # Enable OTPC clock
-        clkreg = self.link.rd_mem(16, self.CLK_AMBA_REG, 1)[0]
-        self.link.wr_mem(16, self.CLK_AMBA_REG, clkreg | 0x200)
-
-        # Mode to standby
-        self.otp_set_mode(self.OTPC_MODE_DSTBY)
-
-        # Default timings
-        self.link.wr_mem(32, self.OTPC_TIM1_REG, self.OTPC_TIM1_REG_RESET)
-        self.link.wr_mem(32, self.OTPC_TIM2_REG, self.OTPC_TIM2_REG_RESET)
-
-    def otp_set_mode(self, mode):
-        """Moves the OTPC in new mode."""
-
-        # Change mode only if new mode is different than the old one
-        otpmode = self.link.rd_mem(32, self.OTPC_MODE_REG, 1)[0]
-        if otpmode != mode:
-            self.link.wr_mem(32, self.OTPC_MODE_REG, mode)
-
-        # Wait for mode change
-        while (self.link.rd_mem(32, self.OTPC_STAT_REG, 1)[0] & 0x4) == 0:
-            pass
-
-    def otp_verify_words(self, words, offset, mode):
-        """Verifies OTP words."""
-
-        # Verify words
-        self.otp_set_mode(mode)
-        for word in words:
-            read = self.link.rd_mem(self.OTP_CFG_SCRIPT_ENTRY_SIZE * 8, self.OTP_CFG_SCRIPT_ADDR + offset, 1)[0]
-            if (read != word):
-                logging.error("OTP verify fail: mode {}, offset 0x{:x}, read 0x{:x}, written 0x{:x}".format(mode, offset, read, word))
-                return False
-            offset += self.OTP_CFG_SCRIPT_ENTRY_SIZE
-        return True
-
-    def otp_write_words(self, words, offset):
-        """Writes OTP words."""
-
-        # Convert offset in config script (in bytes) to offset in cells from start of OTP
-        cell_offset = int((self.OTP_CFG_SCRIPT_OFFSET + offset) / self.OTP_CFG_SCRIPT_ENTRY_SIZE)
-
-        # Write words
-        self.otp_set_mode(self.OTPC_MODE_PROG)
-        for word in words:
-            self.link.wr_mem(32, self.OTPC_PWORD_REG, word)
-            self.link.wr_mem(32, self.OTPC_PADDR_REG, cell_offset)
-            while (self.link.rd_mem(32, self.OTPC_STAT_REG, 1)[0] & 0x2) == 0:
-                pass
-            cell_offset += 1
-
-        # Wait for programming
-        while (self.link.rd_mem(32, self.OTPC_STAT_REG, 1)[0] & 0x1) == 0:
-            pass
-
-        # Verify
-        if not self.otp_verify_words(words, offset, self.OTPC_MODE_PVFY):
-            return False
-        if not self.otp_verify_words(words, offset, self.OTPC_MODE_RINI):
-            return False
-
-        return True
-
-    def otp_read(self, key):
-        """Read the OTP and search for a key
-
-        Args:
-            key: OTP entry to look for, value will be printed
-
-        Returns:
-            count: number of times key was found
-            offset: OTP offset of first free entry, or negative for error
-        """
-
-        # Init OTP
-        self.otp_init()
-        self.otp_set_mode(self.OTPC_MODE_READ)
-
-        # Read whole config script
-        entries = self.link.rd_mem(self.OTP_CFG_SCRIPT_ENTRY_SIZE * 8, self.OTP_CFG_SCRIPT_ADDR, self.OTP_CFG_SCRIPT_ENTRY_CNT_MAX)
-
-        # Parse entries skipping start entry
-        count = 0
-        index = 1
-        while index < self.OTP_CFG_SCRIPT_ENTRY_CNT_MAX:
-            entry = entries[index]
-
-            # Check for key
-            if (entry == key):
-                if (key != 0xffffffff):
-                    logging.info("OTP key found at offset 0x{:x} with value 0x{:x}".format(index * self.OTP_CFG_SCRIPT_ENTRY_SIZE, entries[index + 1]))
-                count += 1
-
-            # Check for end of script
-            if (entry == 0xffffffff):
-                if (count == 0):
-                    logging.info("OTP key not yet in script")
-                logging.info("OTP write offset: 0x{:x}".format(index * self.OTP_CFG_SCRIPT_ENTRY_SIZE))
-                return count, (index * self.OTP_CFG_SCRIPT_ENTRY_SIZE)
-
-            # Check for stop command
-            if (entry == 0x00000000):
-                logging.info("OTP is locked")
-                return count, -2
-
-            logging.debug("OTP {}: {:x}".format(index, entry))
-
-            # Decode entry and skip data values
-            msb = (entry & 0xf0000000) >> 24
-            if (msb == 0x60): # BOOTER
-                index += 1
-            elif (msb == 0x70): # SWD MODE
-                index += 1
-            elif (msb == 0x80): # UART STX
-                index += 1
-            elif (msb == 0x90): # SDK ENTRIES
-                index += 1
-                index += (entry & 0x0000ff00) >> 8
-            else: # REG ENTRIES OR XTAL TRIM
-                index += 2
-
-        logging.info("OTP is full")
-        return count, -1
-
-    def otp_write(self, key, values, force):
-        """Add key and value to the OTP at the first available offset
-
-        Args:
-            key: OTP key to add
-            values: array of OTP values to add
-            force: add key also if it exists
-
-        Returns:
-            result: zero if ok, negative for error
-        """
-    
-        # Get existing count and write offset
-        count, offset = self.otp_read(key)
-
-        # Cannot write when locked or full
-        if (offset < 0):
-            return offset
-
-        # Only write existing keys when forced
-        if (count > 0) and not force:
-            logging.info("OTP write skipped because key exists, use --force to override")
-            return 0
-
-        # Write key with values
-        logging.info("OTP write key 0x{:x} with values: {}".format(key, values))
-        data = [key] + values
-        if not self.otp_write_words(data, offset):
-            logging.error("OTP write error")
-            return -3
-
-        return 0
 
     def read_flash(self, address, length):
         """Read flash.
@@ -1172,9 +988,39 @@ class da1469x(da1468x_da1469x_da1470x):
     PRODUCT_HEADER_SIZE = 0x1000
     IMG_IVT_OFFSET = 0x400
 
+    OTPC_MODE_REG = 0x00  # Mode register
+    OTPC_STAT_REG = 0x04  # Status register
+    OTPC_PADDR_REG = 0x08  # The address of the word that will be programmed
+    OTPC_PWORD_REG = 0x0C  # The 32-bit word that will be programmed
+    OTPC_TIM1_REG = 0x10  # Various timing parameters of the OTP cell
+    OTPC_TIM2_REG = 0x14  # Various timing parameters of the OTP cell
+
+    OTPC_MODE_PDOWN = 0 # OTP cell and LDO are inactive
+    OTPC_MODE_DSTBY = 1 # OTP cell is powered on LDO is inactive
+    OTPC_MODE_STBY = 2 # OTP cell and LDO are powered on, chip select is deactivated
+    OTPC_MODE_READ = 3 # OTP cell can be read
+    OTPC_MODE_PROG = 4 # OTP cell can be programmed
+    OTPC_MODE_PVFY = 5 # OTP cell can be read in PVFY margin read mode
+    OTPC_MODE_RINI = 6 # OTP cell can be read in RINI margin read mode
+    OTPC_TIM1_REG_RESET = 0x0999101f
+    OTPC_TIM2_REG_RESET = 0xa4040409
+
+    OTP_BASE = 0x10080000
+    OTP_CFG_SCRIPT_OFFSET = 0x0C00
+    OTP_CFG_SCRIPT_ADDR = OTP_BASE + OTP_CFG_SCRIPT_OFFSET
+    OTP_CFG_SCRIPT_ENTRY_SIZE = 4
+    OTP_CFG_SCRIPT_ENTRY_CNT_MAX = 256
+
     def __init__(self, name=b"DA1469x"):
         """Initalizate the da14xxxx parent devices class."""
         da1468x_da1469x_da1470x.__init__(self, name)
+
+        self.OTPC_MODE_REG += self.OTPC_BASE
+        self.OTPC_STAT_REG += self.OTPC_BASE
+        self.OTPC_PADDR_REG += self.OTPC_BASE
+        self.OTPC_PWORD_REG += self.OTPC_BASE
+        self.OTPC_TIM1_REG += self.OTPC_BASE
+        self.OTPC_TIM2_REG += self.OTPC_BASE
 
     def make_image_header(self, image):
         """Image header generation.
@@ -1410,6 +1256,165 @@ class da1469x(da1468x_da1469x_da1470x):
         logging.info("[DA1469x] Program success")
         return 1
 
+    def otp_init(self):
+        """Init the OTP controller."""
+
+        # Enable OTPC clock
+        clkreg = self.link.rd_mem(16, self.CLK_AMBA_REG, 1)[0]
+        self.link.wr_mem(16, self.CLK_AMBA_REG, clkreg | 0x200)
+
+        # Mode to standby
+        self.otp_set_mode(self.OTPC_MODE_DSTBY)
+
+        # Default timings
+        self.link.wr_mem(32, self.OTPC_TIM1_REG, self.OTPC_TIM1_REG_RESET)
+        self.link.wr_mem(32, self.OTPC_TIM2_REG, self.OTPC_TIM2_REG_RESET)
+
+    def otp_set_mode(self, mode):
+        """Moves the OTPC in new mode."""
+
+        # Change mode only if new mode is different than the old one
+        otpmode = self.link.rd_mem(32, self.OTPC_MODE_REG, 1)[0]
+        if otpmode != mode:
+            self.link.wr_mem(32, self.OTPC_MODE_REG, mode)
+
+        # Wait for mode change
+        while (self.link.rd_mem(32, self.OTPC_STAT_REG, 1)[0] & 0x4) == 0:
+            pass
+
+    def otp_verify_words(self, words, offset, mode):
+        """Verifies OTP words."""
+
+        # Verify words
+        self.otp_set_mode(mode)
+        for word in words:
+            read = self.link.rd_mem(self.OTP_CFG_SCRIPT_ENTRY_SIZE * 8, self.OTP_CFG_SCRIPT_ADDR + offset, 1)[0]
+            if (read != word):
+                logging.error("OTP verify fail: mode {}, offset 0x{:x}, read 0x{:x}, written 0x{:x}".format(mode, offset, read, word))
+                return False
+            offset += self.OTP_CFG_SCRIPT_ENTRY_SIZE
+        return True
+
+    def otp_write_words(self, words, offset):
+        """Writes OTP words."""
+
+        # Convert offset in config script (in bytes) to offset in cells from start of OTP
+        cell_offset = int((self.OTP_CFG_SCRIPT_OFFSET + offset) / self.OTP_CFG_SCRIPT_ENTRY_SIZE)
+
+        # Write words
+        self.otp_set_mode(self.OTPC_MODE_PROG)
+        for word in words:
+            self.link.wr_mem(32, self.OTPC_PWORD_REG, word)
+            self.link.wr_mem(32, self.OTPC_PADDR_REG, cell_offset)
+            while (self.link.rd_mem(32, self.OTPC_STAT_REG, 1)[0] & 0x2) == 0:
+                pass
+            cell_offset += 1
+
+        # Wait for programming
+        while (self.link.rd_mem(32, self.OTPC_STAT_REG, 1)[0] & 0x1) == 0:
+            pass
+
+        # Verify
+        if not self.otp_verify_words(words, offset, self.OTPC_MODE_PVFY):
+            return False
+        if not self.otp_verify_words(words, offset, self.OTPC_MODE_RINI):
+            return False
+
+        return True
+
+    def otp_read(self, key):
+        """Read the OTP and search for a key
+
+        Args:
+            key: OTP entry to look for, value will be printed
+
+        Returns:
+            count: number of times key was found
+            offset: OTP offset of first free entry, or negative for error
+        """
+
+        # Init OTP
+        self.otp_init()
+        self.otp_set_mode(self.OTPC_MODE_READ)
+
+        # Read whole config script
+        entries = self.link.rd_mem(self.OTP_CFG_SCRIPT_ENTRY_SIZE * 8, self.OTP_CFG_SCRIPT_ADDR, self.OTP_CFG_SCRIPT_ENTRY_CNT_MAX)
+
+        # Parse entries skipping start entry
+        count = 0
+        index = 1
+        while index < self.OTP_CFG_SCRIPT_ENTRY_CNT_MAX:
+            entry = entries[index]
+
+            # Check for key
+            if (entry == key):
+                if (key != 0xffffffff):
+                    logging.info("OTP key found at offset 0x{:x} with value 0x{:x}".format(index * self.OTP_CFG_SCRIPT_ENTRY_SIZE, entries[index + 1]))
+                count += 1
+
+            # Check for end of script
+            if (entry == 0xffffffff):
+                if (count == 0):
+                    logging.info("OTP key not yet in script")
+                logging.info("OTP write offset: 0x{:x}".format(index * self.OTP_CFG_SCRIPT_ENTRY_SIZE))
+                return count, (index * self.OTP_CFG_SCRIPT_ENTRY_SIZE)
+
+            # Check for stop command
+            if (entry == 0x00000000):
+                logging.info("OTP is locked")
+                return count, -2
+
+            logging.debug("OTP {}: {:x}".format(index, entry))
+
+            # Decode entry and skip data values
+            msb = (entry & 0xf0000000) >> 24
+            if (msb == 0x60): # BOOTER
+                index += 1
+            elif (msb == 0x70): # SWD MODE
+                index += 1
+            elif (msb == 0x80): # UART STX
+                index += 1
+            elif (msb == 0x90): # SDK ENTRIES
+                index += 1
+                index += (entry & 0x0000ff00) >> 8
+            else: # REG ENTRIES OR XTAL TRIM
+                index += 2
+
+        logging.info("OTP is full")
+        return count, -1
+
+    def otp_write(self, key, values, force):
+        """Add key and value to the OTP at the first available offset
+
+        Args:
+            key: OTP key to add
+            values: array of OTP values to add
+            force: add key also if it exists
+
+        Returns:
+            result: zero if ok, negative for error
+        """
+
+        # Get existing count and write offset
+        count, offset = self.otp_read(key)
+
+        # Cannot write when locked or full
+        if (offset < 0):
+            return offset
+
+        # Only write existing keys when forced
+        if (count > 0) and not force:
+            logging.info("OTP write skipped because key exists, use --force to override")
+            return 0
+
+        # Write key with values
+        logging.info("OTP write key 0x{:x} with values: {}".format(key, values))
+        data = [key] + values
+        if not self.otp_write_words(data, offset):
+            logging.error("OTP write error")
+            return -3
+
+        return 0
 
 class da1470x(da1469x):
     """Derived class for the da1470x devices."""


### PR DESCRIPTION
Added support for reading and writing OTP configuration script keys on the da1469x. And possibly the da1470x but I cannot test that.

This allows us to set the key required for enabling image size larger than 1MB as described here:
http://lpccs-docs.dialog-semiconductor.com/tutorial_da1469x_supporting_fw_images_bigger_than_512kb/Implementation.html

Command to read:
`ezFlashCLI read_otp <key>`

Command to write:
`ezFlashCLI write_otp <key> <value>`

For the image size, key would be 0x100c0040 and value 0x5.
If the key is already set, write is not done except --force is given.
It's also possible to write keys that require multiple values by just adding more arguments.
