### PR TITLE
Add recognition for 531 variants

### DIFF
--- a/ezFlashCLI/cli.py
+++ b/ezFlashCLI/cli.py
@@ -415,6 +415,17 @@ class ezFlashCLI:
             logging.error("Device not responding: {}".format(inst))
             sys.exit(1)
 
+        if self.deviceType == "da14531":
+            """Try to differentiate between DA14531-00 and DA14531-01"""
+            self.link.connect(self.args.jlink)
+            rom = self.link.rd_mem(8, 0x07F04000, 4)
+            self.link.close()
+            try:
+                self.deviceType = sbdev.DA14531_VARIANTS[str(rom)]
+
+            except Exception:
+                logging.warning("Unknown DA14531 variant")
+
     def probeFlash(self):
         """Look for attached flash."""
         # try:

--- a/ezFlashCLI/ezFlash/smartbond/smartbondDevices.py
+++ b/ezFlashCLI/ezFlash/smartbond/smartbondDevices.py
@@ -99,6 +99,12 @@ SMARTBOND_IDENTIFIER = {
 }
 
 
+DA14531_VARIANTS = {
+    "[7, 33, 1, 112]": "da14531_00",
+    "[32, 70, 254, 247]": "da14531_01",
+}
+
+
 SMARTBOND_PRETTY_IDENTIFIER = {
     "da1470x": "DA1470x",
     "da1469x": "DA1469x",
@@ -107,6 +113,8 @@ SMARTBOND_PRETTY_IDENTIFIER = {
     "da14585": "DA14585/DA14586",
     "da14580": "DA14580",
     "da14531": "DA14531",
+    "da14531_00": "DA14531-00",
+    "da14531_01": "DA14531-01",
 }
 
 
@@ -841,6 +849,22 @@ class da14585(da1453x_da1458x):
 
         # Set SPI Word length
         self.spi_set_bitmode(self.SPI_MODE_8BIT)
+
+
+class da14531_00(da14531):
+    """Derived class for the da14531-00 devices."""
+
+    def __init__(self):
+        """Initalizate the da14531 parent devices class."""
+        da14531.__init__(self)
+
+
+class da14531_01(da14531):
+    """Derived class for the da14531-00 devices."""
+
+    def __init__(self):
+        """Initalizate the da14531 parent devices class."""
+        da14531.__init__(self)
 
 
 class da1468x_da1469x_da1470x(da14xxx):


### PR DESCRIPTION
Add new classes for DA14531-00 and DA14531-01. Recognition is done through reading ROM, as the ID's are identical. If the new recognition fails for any reason it falls back to default DA14531.