### PR TITLE
Fix non-interactive programming of DA14592

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,3 @@
+[*.py]
+indent_style = space
+indent_size = 4

--- a/ezFlashCLI/cli.py
+++ b/ezFlashCLI/cli.py
@@ -411,7 +411,9 @@ class ezFlashCLI:
             device: device name (string)
         """
         assert sbdev  # appease Flake8
-        self.da = eval("sbdev.{}".format(device))()
+        if not hasattr(sbdev, device):
+            raise Exception(f"cannot find device interface class `{device}'")
+        self.da = getattr(sbdev, device)()
         if self.link.iphost:
             self.da.link.iphost = self.link.iphost
 

--- a/ezFlashCLI/ezFlash/smartbond/smartbondDevices.py
+++ b/ezFlashCLI/ezFlash/smartbond/smartbondDevices.py
@@ -1988,6 +1988,14 @@ class da14592(da1469x):
         _592_DEFAULT_IMAGE_OFFSET = 0x400
         if fileData[:4] == b"\xA5\xA5\xA5\xA5":
             logging.info("[DA14592] Program image")
+            self.link.reset()
+            self.link.wr_mem(16, self.SYS_CTRL_REG, self.SYS_CTRL_REG_RESET_VAL)
+            self.link.wr_mem(
+                16,
+                self.SYS_CTRL_REG,
+                self.SYS_CTRL_REG_RESET_VAL | self.SYS_CTRL_REG_SW_RESET_MSK,
+            )
+            self.link.reset()
             self.flash_program_data(fileData, 0x0)
         else:
             if fileData[:2] != b"Qq":
@@ -2032,6 +2040,14 @@ class da14592(da1469x):
             cs += ph
             print(hex(len(cs)))
             logging.info("[DA14592] Program cs script and product headers")
+            self.link.reset()
+            self.link.wr_mem(16, self.SYS_CTRL_REG, self.SYS_CTRL_REG_RESET_VAL)
+            self.link.wr_mem(
+                16,
+                self.SYS_CTRL_REG,
+                self.SYS_CTRL_REG_RESET_VAL | self.SYS_CTRL_REG_SW_RESET_MSK,
+            )
+            self.link.reset()
             self.flash_program_data(cs, 0x0)
         logging.info("[DA14592] Program success")
         return 1

--- a/ezFlashCLI/ezFlash/smartbond/smartbondDevices.py
+++ b/ezFlashCLI/ezFlash/smartbond/smartbondDevices.py
@@ -1866,8 +1866,8 @@ class da1470x(da1469x):
         return True
 
 
-class da14592(da1469x):
-    """Derived class for the da1470x devices."""
+class da1459x(da1469x):
+    """Derived class for the da1459x devices."""
 
     QPSPIC_BASE = 0xA00000
     PRODUCT_HEADER_SIZE = 0x500
@@ -1883,15 +1883,19 @@ class da14592(da1469x):
     HW_FCU_FLASH_ACCESS_MODE_READ = 0x0
     HW_FCU_FLASH_ACCESS_MODE_WRITE_ERASE = 0x8
 
+    WATCHDOG_REG = 0x50000700
     SYS_CTRL_REG = 0x50000024
-    SYS_CTRL_REG_RESET_VAL = 0xA0
+    SYS_CTRL_REG_RESET_VAL = 0x00A0
 
     def __init__(self):
         """Initalizate the da14xxxx parent devices class."""
+        # NOTE: this value is passed to JLink, which makes a distinction
+        # between the DA14592 and 594. With regards to flashing they are
+        # identical, so this shouldn't matter
         da1469x.__init__(self, b"DA14592")
 
     def flash_probe(self):
-        """Return dummy value for DA14592."""
+        """Return dummy value for DA1459x."""
         return (1, 2, 3)
 
     def flash_hw_qspi_cs_enable(self):
@@ -1990,13 +1994,12 @@ class da14592(da1469x):
             logging.info("[DA14592] Program image")
             self.link.reset()
             self.link.wr_mem(16, self.SYS_CTRL_REG, self.SYS_CTRL_REG_RESET_VAL)
-            self.link.wr_mem(
-                16,
-                self.SYS_CTRL_REG,
-                self.SYS_CTRL_REG_RESET_VAL | self.SYS_CTRL_REG_SW_RESET_MSK,
-            )
-            self.link.reset()
             self.flash_program_data(fileData, 0x0)
+            # set the watchdog timer to 0 to cause a reset (regular reset
+            # doesn't seem to work here for some reason)
+            self.link.reset()
+            self.link.wr_mem(16, self.WATCHDOG_REG, 0)
+            self.link.go()
         else:
             if fileData[:2] != b"Qq":
                 logging.info("[DA14592] Add image header")

--- a/ezFlashCLI/ezFlash/smartbond/supportedDevices.py
+++ b/ezFlashCLI/ezFlash/smartbond/supportedDevices.py
@@ -41,8 +41,8 @@ devices = [
     smartbond_device("da1469x", "DA1469x", "[51, 48, 56, 48]", 0x50040200, 4, 32),
     smartbond_device("da1470x", "DA1470x", "[50, 55, 57, 56]", 0x50040000, 4, 32),
     smartbond_device("da1470x", "DA1470x", "[51, 49, 48, 55]", 0x50040000, 4, 32),
-    smartbond_device("da14592", "DA14592", "[50, 54, 51, 52, 2]", 0x50050200, 5, 32),
-    smartbond_device("da14592", "DA14594", "[50, 54, 51, 52, 3]", 0x50050200, 5, 32),
+    smartbond_device("da1459x", "DA14592", "[50, 54, 51, 52, 2]", 0x50050200, 5, 32),
+    smartbond_device("da1459x", "DA14594", "[50, 54, 51, 52, 3]", 0x50050200, 5, 32),
     smartbond_device("da14531", "DA14535", "[51, 0, 51, 0, 48]", 0x50003200, 5, 8),
     smartbond_device(
         "da14531_00",


### PR DESCRIPTION
This PR adds a watchdog reset to the `da1459x::flash_program_image` function in order to properly reset the DA14592 after reset without any user interaction.